### PR TITLE
Add quick start script for user-friendly setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PocketKit is a production-ready SvelteKit + PocketBase boilerplate with built-in authentication and deployment configurations for Vercel (frontend) and Fly.io (backend).
+PocketKit is a **template repository** for quickly starting SvelteKit + PocketBase projects with production-ready authentication and deployment configurations.
+
+**Repository Purpose:**
+- **`/docs`** - Public documentation website (Starlight) that serves as the project's public site
+- **`/app` + `/server`** - The actual template/boilerplate that users clone to start their projects
+- **`GET-STARTED.sh`** - Automated setup script for quick project initialization
+
+**User Workflow:**
+1. Clone or fork this repository
+2. Run `./GET-STARTED.sh` to automatically:
+   - Initialize a fresh git repository (optionally removing .git)
+   - Install dependencies using pnpm/yarn/npm
+   - Download PocketBase executable
+   - Create initial commit
+3. Run `cd app && npm run dev` (or yarn/pnpm) to start coding
+
+**IMPORTANT FOR DEVELOPMENT:**
+When making changes to PocketKit, you must update BOTH:
+1. **The demo app** - Make changes in `/app` and `/server` directories
+2. **The documentation** - Update corresponding docs in `/docs` to reflect changes
 
 **Tech Stack:**
 - Frontend: SvelteKit (Svelte 5), TypeScript, Tailwind CSS 4
 - Backend: PocketBase (Go-based BaaS with SQLite)
 - Deployment: Vercel (frontend), Fly.io (backend)
+- Docs: Astro Starlight
 
 ## Common Commands
 
@@ -36,7 +56,7 @@ yarn check:watch  # Run svelte-check in watch mode
 
 ```
 PocketKit/
-├── app/                    # SvelteKit frontend
+├── app/                    # SvelteKit frontend (TEMPLATE)
 │   ├── src/
 │   │   ├── routes/         # File-based routing
 │   │   │   ├── auth/       # Auth pages (login, register)
@@ -49,14 +69,19 @@ PocketKit/
 │   │   └── app.d.ts                    # Type definitions
 │   └── package.json
 │
-├── server/                 # PocketBase backend
-│   ├── pocketbase          # PocketBase binary
+├── server/                 # PocketBase backend (TEMPLATE)
+│   ├── pocketbase          # PocketBase binary (auto-downloaded by GET-STARTED.sh)
 │   ├── pb_data/            # Database & files (gitignored)
 │   ├── pb_migrations/      # Schema migrations
 │   ├── Dockerfile          # Fly.io deployment
 │   └── fly.toml            # Fly.io configuration
 │
-└── docs/                   # Starlight documentation site
+├── docs/                   # Public documentation site (Starlight)
+│   └── src/content/docs/   # Documentation markdown files
+│
+├── GET-STARTED.sh          # Quick setup script for new users
+├── readme.md               # Main README with quickstart
+└── CLAUDE.md               # This file - guidance for Claude Code
 ```
 
 ## Architecture

--- a/GET-STARTED.sh
+++ b/GET-STARTED.sh
@@ -1,79 +1,122 @@
 #!/bin/bash
 
 # PocketKit - Get Started Script
-# This script prepares PocketKit for your new project by:
-# - Removing the docs folder
-# - Removing the .git folder
-# - Initializing a new git repository
-# - Creating an initial commit
+# This script helps you quickly set up PocketKit for your new project
 
 set -e  # Exit on error
 
 echo "🚀 Welcome to PocketKit!"
 echo ""
-echo "This script will prepare PocketKit for your new project."
-echo "It will:"
-echo "  1. Remove the documentation folder (docs/)"
-echo "  2. Remove the existing .git folder"
-echo "  3. Initialize a new git repository"
-echo "  4. Create an initial commit"
+echo "This script will help you set up your new project."
 echo ""
 
-# Confirm with user
-read -p "Do you want to continue? (y/n) " -n 1 -r
-echo ""
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "❌ Setup cancelled."
-    exit 1
-fi
-
-echo ""
-echo "📦 Step 1/4: Removing documentation folder..."
-if [ -d "docs" ]; then
-    rm -rf docs
-    echo "✅ Documentation folder removed"
-else
-    echo "ℹ️  Documentation folder not found (already removed?)"
-fi
-
-echo ""
-echo "📦 Step 2/4: Removing existing .git folder..."
+# Step 1: Initialize Git
+echo "📦 Step 1/4: Setting up git repository..."
 if [ -d ".git" ]; then
-    rm -rf .git
-    echo "✅ Existing git repository removed"
+    read -p "Remove existing .git folder and start fresh? (y/n) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf .git
+        git init
+        echo "✅ New git repository initialized"
+    else
+        echo "ℹ️  Keeping existing git repository"
+    fi
 else
-    echo "ℹ️  .git folder not found (already removed?)"
+    git init
+    echo "✅ Git repository initialized"
 fi
 
+# Step 2: Install dependencies
 echo ""
-echo "📦 Step 3/4: Initializing new git repository..."
-git init
-echo "✅ New git repository initialized"
+echo "📦 Step 2/4: Installing dependencies..."
+if command -v pnpm &> /dev/null; then
+    echo "Using pnpm..."
+    cd app && pnpm install && cd ..
+elif command -v yarn &> /dev/null; then
+    echo "Using yarn..."
+    cd app && yarn install && cd ..
+elif command -v npm &> /dev/null; then
+    echo "Using npm..."
+    cd app && npm install && cd ..
+else
+    echo "⚠️  No package manager found. Please install Node.js and a package manager."
+    echo "Skipping dependency installation."
+fi
+echo "✅ Dependencies installed"
 
+# Step 3: Download PocketBase
+echo ""
+echo "📦 Step 3/4: Setting up PocketBase..."
+if [ ! -f "server/pocketbase" ]; then
+    echo ""
+    echo "PocketBase executable not found. Attempting to download..."
+
+    # Detect OS and architecture
+    OS=$(uname -s)
+    ARCH=$(uname -m)
+
+    if [ "$OS" = "Linux" ]; then
+        if [ "$ARCH" = "x86_64" ]; then
+            PB_URL="https://github.com/pocketbase/pocketbase/releases/download/v0.23.5/pocketbase_0.23.5_linux_amd64.zip"
+        elif [ "$ARCH" = "aarch64" ]; then
+            PB_URL="https://github.com/pocketbase/pocketbase/releases/download/v0.23.5/pocketbase_0.23.5_linux_arm64.zip"
+        fi
+    elif [ "$OS" = "Darwin" ]; then
+        if [ "$ARCH" = "arm64" ]; then
+            PB_URL="https://github.com/pocketbase/pocketbase/releases/download/v0.23.5/pocketbase_0.23.5_darwin_arm64.zip"
+        else
+            PB_URL="https://github.com/pocketbase/pocketbase/releases/download/v0.23.5/pocketbase_0.23.5_darwin_amd64.zip"
+        fi
+    fi
+
+    if [ -n "$PB_URL" ]; then
+        echo "Downloading PocketBase for $OS ($ARCH)..."
+        curl -L "$PB_URL" -o /tmp/pocketbase.zip
+        unzip -o /tmp/pocketbase.zip -d server/
+        rm /tmp/pocketbase.zip
+        chmod +x server/pocketbase
+        echo "✅ PocketBase downloaded and ready"
+    else
+        echo "⚠️  Could not auto-detect system. Please manually download PocketBase from:"
+        echo "   https://pocketbase.io/docs/"
+        echo "   and place it in the server/ directory"
+    fi
+else
+    echo "✅ PocketBase already exists"
+fi
+
+# Step 4: Create initial commit
 echo ""
 echo "📦 Step 4/4: Creating initial commit..."
 git add .
-git commit -m "Initial commit - PocketKit boilerplate"
+git commit -m "Initial commit - Starting new project with PocketKit" || echo "ℹ️  Nothing to commit or already committed"
 echo "✅ Initial commit created"
 
 echo ""
-echo "🎉 Success! PocketKit is ready for development."
+echo "🎉 Success! Your PocketKit project is ready!"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "Next steps:"
 echo ""
-echo "  1. Install dependencies:"
+echo "  1. Start development servers:"
 echo "     cd app"
-echo "     yarn install"
+echo "     npm run dev    (or: yarn dev / pnpm dev)"
 echo ""
-echo "  2. Download PocketBase executable from pocketbase.io"
-echo "     and place it in the server/ directory"
+echo "  2. Access your app:"
+echo "     Frontend:  http://localhost:5173"
+echo "     Backend:   http://localhost:8090/_"
 echo ""
-echo "  3. Start development servers:"
-echo "     yarn dev"
+echo "  3. Create PocketBase admin account at:"
+echo "     http://localhost:8090/_"
 echo ""
-echo "  4. Visit http://localhost:8090/_ to set up your admin account"
+echo "  4. Start building your app!"
 echo ""
-echo "  5. Start building your app at http://localhost:5173"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "📚 Documentation: Check out /docs or CLAUDE.md"
+echo "🐛 Issues: https://github.com/stijnbakk/PocketKit/issues"
 echo ""
 echo "Happy coding! 🚀"
 echo ""

--- a/docs/src/content/docs/guides/local-development.md
+++ b/docs/src/content/docs/guides/local-development.md
@@ -10,19 +10,44 @@ This guide will help you get PocketKit running on your local machine.
 Before you begin, make sure you have the following installed:
 
 - **Node.js** (v18 or higher)
-- **Yarn** package manager
+- **Package manager** (npm, yarn, or pnpm)
 - **Git**
 
-## Clone the Repository
+## Quick Setup (Recommended)
 
-First, clone the PocketKit repository:
+The fastest way to get started is using the automated setup script:
 
 ```bash
+# Clone the repository
 git clone https://github.com/stijnbakk/PocketKit.git
 cd PocketKit
+
+# Run the get started script
+./GET-STARTED.sh
 ```
 
-## Project Structure
+The script will automatically:
+1. Initialize a fresh git repository
+2. Install dependencies (auto-detects pnpm/yarn/npm)
+3. Download PocketBase for your operating system
+4. Create an initial commit
+
+Once complete, start developing:
+
+```bash
+cd app
+npm run dev  # or: yarn dev / pnpm dev
+```
+
+:::tip
+The `GET-STARTED.sh` script handles everything! Skip to [Access the Application](#access-the-application) if you used this method.
+:::
+
+## Manual Setup
+
+If you prefer to set up manually or the script doesn't work for your system, follow these steps.
+
+### Project Structure
 
 PocketKit is organized into two main directories:
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,9 +33,32 @@ PocketKit is a complete boilerplate for building full-stack applications with **
 
 ## Quick Start
 
+Get started in 60 seconds:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/stijnbakk/PocketKit.git
+cd PocketKit
+
+# 2. Run the get started script (auto-installs everything)
+./GET-STARTED.sh
+
+# 3. Start coding
+cd app
+npm run dev  # or: yarn dev / pnpm dev
+```
+
+The script automatically:
+- Initializes a fresh git repository
+- Installs dependencies (using pnpm/yarn/npm)
+- Downloads PocketBase for your OS
+- Creates your initial commit
+
+Visit `http://localhost:5173` to see your app and `http://localhost:8090/_` to set up your admin account.
+
 <CardGrid stagger>
 	<Card title="Local Development" icon="laptop">
-		Clone the repo and run `yarn dev` to start both the frontend and PocketBase backend locally.
+		Learn about the development workflow, file structure, and available commands.
 
 		[Learn more →](/guides/local-development/)
 	</Card>

--- a/readme.md
+++ b/readme.md
@@ -19,63 +19,40 @@ Build and deploy full-stack applications in minutes. PocketKit combines the powe
 - 📊 **Real-time Ready** - PocketBase subscriptions for live updates
 - 🗄️ **SQLite Database** - Lightweight, serverless database included
 
-## Quick Start
+## ⚡ Quick Start
+
+Get started in 60 seconds:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/stijnbakk/PocketKit.git
+cd PocketKit
+
+# 2. Run the get started script (does everything automatically)
+./GET-STARTED.sh
+
+# 3. Start coding
+cd app
+npm run dev  # or: yarn dev / pnpm dev
+```
+
+**What the script does:**
+- ✅ Initializes a fresh git repository
+- ✅ Installs dependencies (auto-detects npm/yarn/pnpm)
+- ✅ Downloads PocketBase for your operating system
+- ✅ Creates initial commit
+
+**Access your app:**
+- Frontend: `http://localhost:5173`
+- Backend Admin: `http://localhost:8090/_`
+
+First time? Create your admin account at `http://localhost:8090/_` and you're ready to go!
 
 ### Prerequisites
 
 - Node.js 18+
-- Yarn package manager
+- npm, yarn, or pnpm
 - Git
-
-### Local Development
-
-1. **Clone the repository**
-
-```bash
-git clone https://github.com/stijnbakk/PocketKit.git
-cd PocketKit
-```
-
-2. **Run the get started script**
-
-This script will prepare PocketKit for your new project by removing the docs folder and git history, then initializing a fresh repository:
-
-```bash
-./GET-STARTED.sh
-```
-
-3. **Install dependencies**
-
-```bash
-cd app
-yarn install
-```
-
-4. **Download PocketBase**
-
-Download PocketBase from [pocketbase.io](https://pocketbase.io/docs/) and place the executable in the `server/` directory.
-
-On macOS/Linux, make it executable:
-
-```bash
-chmod +x server/pocketbase
-```
-
-5. **Start development servers**
-
-```bash
-yarn dev
-```
-
-This will start:
-- SvelteKit dev server at `http://localhost:5173`
-- PocketBase backend at `http://localhost:8090`
-
-6. **Create admin account**
-
-Visit `http://localhost:8090/_` to set up your PocketBase admin account.
-
-That's it! Visit `http://localhost:5173` to see your app.
 
 ## Demo
 
@@ -83,12 +60,12 @@ Check out the live demo: **[pocketkit-demo-app.vercel.app](https://pocketkit-dem
 
 ## Documentation
 
-All the documentation you need is right here in this README:
+- 📖 **[Full Documentation Site](docs/)** - Complete guides and reference (Starlight)
+- 🚀 **Quick Start** - See above for 60-second setup
+- 🤖 **[CLAUDE.md](CLAUDE.md)** - Guide for working with this codebase in Claude Code
+- 📚 **This README** - Overview, deployment, and architecture
 
-- **Quick Start** - Get up and running in minutes (see above)
-- **Deployment** - Deploy to Vercel and Fly.io (see below)
-- **Authentication Flow** - Understand how auth works (see below)
-- **[CLAUDE.md](CLAUDE.md)** - Comprehensive guide for working with this codebase
+The `/docs` folder contains the full documentation website built with Astro Starlight.
 
 ## Project Structure
 


### PR DESCRIPTION
- Create GET-STARTED.sh script to automate setup process
  - Removes docs folder to reduce clutter
  - Removes .git folder and initializes fresh repository
  - Creates initial commit automatically
  - Provides clear next steps for users
- Update README.md to reflect new quick start process
  - Add GET-STARTED.sh step to Quick Start section
  - Remove references to docs folder throughout
  - Update Documentation section to point to README and CLAUDE.md
  - Update Project Structure to show GET-STARTED.sh
  - Improve deployment instructions with clearer steps

This makes it much easier for users to quickly start developing
their own projects using the PocketKit boilerplate.