### PR TITLE
Add package manager tabs to documentation

### DIFF
--- a/docs/src/content/docs/guides/deployment.mdx
+++ b/docs/src/content/docs/guides/deployment.mdx
@@ -3,6 +3,8 @@ title: Deployment Guide
 description: Deploy your PocketKit app to Vercel and Fly.io
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 This guide covers deploying PocketKit to production using free hosting:
 - **Frontend (SvelteKit)** → Vercel
 - **Backend (PocketBase)** → Fly.io
@@ -138,9 +140,23 @@ Log in with your superuser credentials.
 
 You can deploy via GitHub integration (recommended) or CLI:
 
-```bash
-npm i -g vercel
-```
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  ```bash
+  yarn global add vercel
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  pnpm add -g vercel
+  ```
+  </TabItem>
+  <TabItem label="npm">
+  ```bash
+  npm i -g vercel
+  ```
+  </TabItem>
+</Tabs>
 
 ### Connect to GitHub
 
@@ -156,8 +172,19 @@ When setting up the project:
 
 1. **Framework Preset**: SvelteKit (should be auto-detected)
 2. **Root Directory**: `app`
-3. **Build Command**: `yarn build` (default)
-4. **Output Directory**: `.svelte-kit` (default)
+3. **Output Directory**: `.svelte-kit` (default)
+
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  **Build Command**: `yarn build` (default)
+  </TabItem>
+  <TabItem label="pnpm">
+  **Build Command**: `pnpm build`
+  </TabItem>
+  <TabItem label="npm">
+  **Build Command**: `npm run build` (default)
+  </TabItem>
+</Tabs>
 
 ### Set Environment Variables
 

--- a/docs/src/content/docs/guides/local-development.mdx
+++ b/docs/src/content/docs/guides/local-development.mdx
@@ -3,6 +3,8 @@ title: Local Development
 description: Learn how to run PocketKit locally for development
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 This guide will help you get PocketKit running on your local machine.
 
 ## Prerequisites
@@ -38,15 +40,41 @@ Then it will automatically:
 
 Once complete, start developing:
 
-```bash
-# For SvelteKit
-cd app-svelte
-npm run dev  # or: yarn dev / pnpm dev
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  ```bash
+  # For SvelteKit
+  cd app-svelte
+  yarn dev
 
-# For React/Next.js
-cd app-react
-npm run dev  # or: yarn dev / pnpm dev
-```
+  # For React/Next.js
+  cd app-react
+  yarn dev
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  # For SvelteKit
+  cd app-svelte
+  pnpm dev
+
+  # For React/Next.js
+  cd app-react
+  pnpm dev
+  ```
+  </TabItem>
+  <TabItem label="npm">
+  ```bash
+  # For SvelteKit
+  cd app-svelte
+  npm run dev
+
+  # For React/Next.js
+  cd app-react
+  npm run dev
+  ```
+  </TabItem>
+</Tabs>
 
 :::tip
 The `GET-STARTED.sh` script handles everything! Skip to [Access the Application](#access-the-application) if you used this method.
@@ -74,15 +102,41 @@ Choose one app directory based on your preferred framework.
 
 Navigate to your chosen app directory and install the dependencies:
 
-```bash
-# For SvelteKit
-cd app-svelte
-yarn install
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  ```bash
+  # For SvelteKit
+  cd app-svelte
+  yarn install
 
-# OR for React/Next.js
-cd app-react
-npm install
-```
+  # OR for React/Next.js
+  cd app-react
+  yarn install
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  # For SvelteKit
+  cd app-svelte
+  pnpm install
+
+  # OR for React/Next.js
+  cd app-react
+  pnpm install
+  ```
+  </TabItem>
+  <TabItem label="npm">
+  ```bash
+  # For SvelteKit
+  cd app-svelte
+  npm install
+
+  # OR for React/Next.js
+  cd app-react
+  npm install
+  ```
+  </TabItem>
+</Tabs>
 
 ## Download PocketBase
 
@@ -105,20 +159,54 @@ chmod +x ../server/pocketbase
 From your chosen app directory, run:
 
 **SvelteKit:**
-```bash
-cd app-svelte
-yarn dev
-```
+
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  ```bash
+  cd app-svelte
+  yarn dev
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  cd app-svelte
+  pnpm dev
+  ```
+  </TabItem>
+  <TabItem label="npm">
+  ```bash
+  cd app-svelte
+  npm run dev
+  ```
+  </TabItem>
+</Tabs>
 
 This single command will:
 - Start the SvelteKit dev server on `http://localhost:5173`
 - Launch PocketBase on `http://localhost:8090`
 
 **React/Next.js:**
-```bash
-cd app-react
-npm run dev
-```
+
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  ```bash
+  cd app-react
+  yarn dev
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  cd app-react
+  pnpm dev
+  ```
+  </TabItem>
+  <TabItem label="npm">
+  ```bash
+  cd app-react
+  npm run dev
+  ```
+  </TabItem>
+</Tabs>
 
 This single command will:
 - Start the Next.js dev server on `http://localhost:3000`
@@ -251,7 +339,7 @@ On macOS, you might see a security warning when running PocketBase:
 1. Go to **System Settings** → **Privacy & Security**
 2. Look for a message about PocketBase being blocked
 3. Click **Allow Anyway**
-4. Run `yarn dev` again
+4. Run the dev command again
 
 ## Next Steps
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,7 +19,7 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## What is PocketKit?
 
@@ -43,11 +43,31 @@ cd PocketKit
 # 2. Run the get started script (auto-installs everything)
 ./GET-STARTED.sh
 # Choose between SvelteKit or React/Next.js
-
-# 3. Start coding
-cd app-svelte  # or app-react
-npm run dev    # or: yarn dev / pnpm dev
 ```
+
+<Tabs syncKey="package-managers">
+  <TabItem label="yarn">
+  ```bash
+  # 3. Start coding
+  cd app-svelte  # or app-react
+  yarn dev
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  # 3. Start coding
+  cd app-svelte  # or app-react
+  pnpm dev
+  ```
+  </TabItem>
+  <TabItem label="npm">
+  ```bash
+  # 3. Start coding
+  cd app-svelte  # or app-react
+  npm run dev
+  ```
+  </TabItem>
+</Tabs>
 
 The script automatically:
 - Lets you choose between SvelteKit or React/Next.js


### PR DESCRIPTION
## Summary

This PR adds package manager tabs (yarn/pnpm/npm) to the documentation using Starlight's Tabs component.

## Changes

- Converted documentation files to MDX format to support Starlight Tabs component
- Added synchronized tabs using `syncKey='package-managers'` for consistent UX
- Set yarn as the default (first) tab option
- Updated index.mdx Quick Start section with tabbed commands
- Updated local-development guide with tabs for all package manager commands
- Updated deployment guide with tabs for Vercel CLI install and build commands

Closes #11

---

Generated with [Claude Code](https://claude.ai/code)